### PR TITLE
Cannot read property 'replace' of undefined

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -19,11 +19,15 @@ function yarnToNpmResolved (version, yarnResolved) {
 }
 
 function npmToYarnResolved (resolved, integrity) {
-  const hexChecksum = /^sha1-/.test(integrity)
-    ? Buffer.from(integrity.replace(/^sha1-/, ''), 'base64').toString('hex')
-    : Buffer.from(integrity.replace(/^sha512-/, ''), 'base64').toString('hex')
-    // see caveats in README
-  return `${resolved}#${hexChecksum}`
+  if (integrity) {
+    const hexChecksum = /^sha1-/.test(integrity)
+      ? Buffer.from(integrity.replace(/^sha1-/, ''), 'base64').toString('hex')
+      : Buffer.from(integrity.replace(/^sha512-/, ''), 'base64').toString('hex')
+      // see caveats in README
+    return `${resolved}#${hexChecksum}`
+  }
+
+  return resolved
 }
 
 module.exports = {


### PR DESCRIPTION
When dependency is installed form git there is now `integrity` in `package-lock.json`

