### PR TITLE
fix: provide support for `packages` when `dependencies` do not exist (package-lock v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.9.11](https://github.com/imsnif/synp/compare/v1.9.11...v1.9.10) (2024-04-26)
+
+### Bug Fixes
+* fix: allow for `packageLock.packages` to resolve some package-lock v3 failures
+
 ## [1.9.10](https://github.com/imsnif/synp/compare/v1.9.9...v1.9.10) (2022-02-10)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-## [1.9.11](https://github.com/imsnif/synp/compare/v1.9.11...v1.9.10) (2024-04-26)
-
-### Bug Fixes
-* fix: allow for `packageLock.packages` to resolve some package-lock v3 failures
-
 ## [1.9.10](https://github.com/imsnif/synp/compare/v1.9.9...v1.9.10) (2022-02-10)
 
 

--- a/lib/lockfileV1/tree.js
+++ b/lib/lockfileV1/tree.js
@@ -21,7 +21,7 @@ const {
 
 module.exports = {
   buildYarnTree (nodeModulesTree, packageLock) {
-    const flattenedPackageLock = flattenPackageLock(packageLock.dependencies)
+    const flattenedPackageLock = flattenPackageLock(packageLock.dependencies ?? packageLock.packages)
     const tree = Object.keys(nodeModulesTree).reduce((tree, path) => {
       const nmEntry = nodeModulesTree[path]
       const { name } = nmEntry

--- a/lib/lockfileV1/tree.js
+++ b/lib/lockfileV1/tree.js
@@ -21,7 +21,7 @@ const {
 
 module.exports = {
   buildYarnTree (nodeModulesTree, packageLock) {
-    const flattenedPackageLock = flattenPackageLock(packageLock.dependencies ?? packageLock.packages)
+    const flattenedPackageLock = flattenPackageLock(packageLock.dependencies || packageLock.packages)
     const tree = Object.keys(nodeModulesTree).reduce((tree, path) => {
       const nmEntry = nodeModulesTree[path]
       const { name } = nmEntry

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synp",
-  "version": "1.9.10",
+  "version": "1.9.11",
   "description": "Convert yarn.lock to package-lock.json and vice versa",
   "keywords": [
     "yarn",


### PR DESCRIPTION
Doing some testing on failures happening with converting package-lock.json files with `"lockfileVersion": 3`, and tested out the solution mentioned in this issue: https://github.com/imsnif/synp/issues/99

Using this fork, I was able to get a successful conversion, where previous attempts with package-lock.json v3 had failed.
